### PR TITLE
Changes for 0.0.1b release

### DIFF
--- a/funcworks/utils/workflow.py
+++ b/funcworks/utils/workflow.py
@@ -105,3 +105,13 @@ def correct_matrix(design_matrix):
         sep='\t', line_terminator='\t\n',
         mode='a', header=None)
     return str(matrix_path)
+
+def reference_outputs(**args):
+    def _pop(inlist):
+        if isinstance(inlist, (list, tuple)) and len(inlist) == 1:
+            return inlist[0]
+        return inlist
+    popped_lists = {}
+    for arg in args:
+        popped_lists[arg] = _pop(args[arg])
+    return popped_lists['brain_mask'], popped_lists['bold_ref']

--- a/funcworks/workflows/base.py
+++ b/funcworks/workflows/base.py
@@ -10,6 +10,7 @@ def init_funcworks_wf(model_file,
                       bids_dir,
                       output_dir,
                       work_dir,
+                      database_path,
                       participants,
                       analysis_level,
                       smoothing,
@@ -25,6 +26,7 @@ def init_funcworks_wf(model_file,
     funcworks_wf = Workflow(name='funcworks_wf')
     (work_dir / model['Name']).mkdir(exist_ok=True, parents=True)
     funcworks_wf.base_dir = work_dir / model['Name']
+
     if smoothing:
         smoothing_params = smoothing.split(':')
         if len(smoothing_params) == 1:
@@ -49,6 +51,7 @@ def init_funcworks_wf(model_file,
                                                                   'funcworks' /
                                                                   model['Name']),
                                                       work_dir=work_dir,
+                                                      database_path=database_path,
                                                       subject_id=subject_id,
                                                       analysis_level=analysis_level,
                                                       smoothing_fwhm=smoothing_fwhm,
@@ -76,6 +79,7 @@ def init_funcworks_subject_wf(model,
                               bids_dir,
                               output_dir,
                               work_dir,
+                              database_path,
                               subject_id,
                               analysis_level,
                               smoothing_fwhm,
@@ -97,6 +101,7 @@ def init_funcworks_subject_wf(model,
                                      bids_dir=bids_dir,
                                      output_dir=output_dir,
                                      work_dir=work_dir,
+                                     database_path=database_path,
                                      subject_id=subject_id,
                                      smoothing_fwhm=smoothing_fwhm,
                                      smoothing_level=smoothing_level,


### PR DESCRIPTION
ENH: Switched from using nipype.interfaces.io BIDSDataGrabber for inhouse modifications of it, allows for reading in of database_file.
ENH: New --database-path flag to indicate location of bids database cache information to speedup runtime
MAINT: Changed run level workflow to accomodate align volumes and models that don't use align volumes
MAINT: Minor rework to `bids_split_filename` from os.path to pathlib.Path
MAINT: Added initial creation of bids_layout during runtime in order to accomodate new --database-path argument