### PR TITLE
[REF][FIX] Fix behavior for datasets with no 'run' entity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,17 +155,13 @@ jobs:
                 docker images
               fi
         - run:
-            name: Check outputs
-            command: |
-              python -c "import pathlib; print(list(pathlib.Path('/tmp/data/ds003_fmriprep/').rglob('**/*.*')))"
-        - run:
             name: Run Funcworks
             no_output_timeout: 2h
             command: |
               mkdir -p /tmp/ds003/work /tmp/ds003/derivatives
               chmod 777 /tmp/ds003/work /tmp/ds003/derivatives
               export CONDA_PREFIX=/opt/conda/envs/neuro
-              docker run --rm -v /tmp/data/ds003_fmriprep:/data:ro \
+              docker run --rm -v /tmp/data/ds003_fmriprep:/data: \
                   -v /tmp/ds003/derivatives:/out \
                   -v /tmp/ds003/work:/scratch \
                   -v /tmp/data/ds003_models:/models \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
             datalad get ds003_fmriprep/sub-0{1,2,3}/func/*_space-MNI152NLin2009cAsym_desc-*.nii.gz \
                         ds003_fmriprep/sub-0{1,2,3}/func/*_desc-confounds_*.tsv \
                         ds003_fmriprep/dataset_description.json \
-                        ds003_fmriprep/sub-*/*/*.json
+                        ds003_fmriprep/sub-0{1,2,3}/*/*.json
       - run:
           name: Download a model for ds000003
           command: |
@@ -154,6 +154,10 @@ jobs:
                 pigz -d --stdout /tmp/cache/docker.tar.gz | docker load
                 docker images
               fi
+        - run:
+            name: Check outputs
+            command: |
+              python -c "import pathlib; print(pathlib.Path('/data/sub-03/func/sub-03_task-rhymejudgment_space-MNI152NLin6Asym_desc-preproc_bold.nii.gz').is_file())"
         - run:
             name: Run Funcworks
             no_output_timeout: 2h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
         - run:
             name: Check outputs
             command: |
-              python -c "import pathlib; print(pathlib.Path('/tmp/data/ds003_fmriprep/sub-03/func/sub-03_task-rhymejudgment_space-MNI152NLin6Asym_desc-preproc_bold.nii.gz').is_file())"
+              python -c "import pathlib; print(list(pathlib.Path('/tmp/data/ds003_fmriprep/').rglob('**/*.*')))"
         - run:
             name: Run Funcworks
             no_output_timeout: 2h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
         - run:
             name: Check outputs
             command: |
-              python -c "import pathlib; print(pathlib.Path('/data/sub-03/func/sub-03_task-rhymejudgment_space-MNI152NLin6Asym_desc-preproc_bold.nii.gz').is_file())"
+              python -c "import pathlib; print(pathlib.Path('/tmp/data/ds003_fmriprep/sub-03/func/sub-03_task-rhymejudgment_space-MNI152NLin6Asym_desc-preproc_bold.nii.gz').is_file())"
         - run:
             name: Run Funcworks
             no_output_timeout: 2h

--- a/funcworks/cli/run.py
+++ b/funcworks/cli/run.py
@@ -84,10 +84,11 @@ def get_parser():
         help='Legendre polynomials to use for temporal filtering.')
     parser.add_argument(
         '--align-volumes', action='store',
-        default=1, type=int,
+        default=None, type=int,
         help='Bold reference to align timeseries, '
-             'this will override any run specific inputs '
-             'in the model file for the boldref and brain_mask.')
+             'this will override any run specific entities '
+             'or specifications in the model file '
+             'for the boldref and brain_mask.')
     parser.add_argument(
         '--database-path', action='store', default=None,
         help='Path to existing directory containing BIDS '
@@ -139,7 +140,7 @@ def main():
         # output_dir = retval.get('output_dir')
         # work_dir = retval.get('work_dir')
         # subject_list = retval.get('participant_label', None)
-        # run_uuid = retval.get('run_uuid', None)
+        # runtime_uuid = retval.get('runtime_uuid', None)
         plugin_settings = retval.get('plugin_settings')
         funcworks_wf = retval.get('workflow', None)
 
@@ -166,7 +167,7 @@ def main():
         #     from ..utils.sentry import process_crashfile
         #     crashfolders = [
         #         output_dir / 'funcworks' / 'sub-{}'.format(s) /
-        #         'log' / run_uuid for s in subject_list]
+        #         'log' / runtime_uuid for s in subject_list]
         #    for crashfolder in crashfolders:
         #         for crashfile in crashfolder.glob('crash*.*'):
         #             process_crashfile(crashfile)
@@ -233,8 +234,8 @@ def build_workflow(opts, retval):
         return retval
 
     # Set up some instrumental utilities
-    run_uuid = '%s_%s' % (strftime('%Y%m%d-%H%M%S'), uuid.uuid4())
-    retval['run_uuid'] = run_uuid
+    runtime_uuid = '%s_%s' % (strftime('%Y%m%d-%H%M%S'), uuid.uuid4())
+    retval['runtime_uuid'] = runtime_uuid
 
     if opts.participant_label:
         retval['participant_label'] = opts.participant_label
@@ -306,11 +307,11 @@ def build_workflow(opts, retval):
     # if opts.reports_only:
     #     build_log.log(25, 'Running --reports-only on participants %s',
     #                   ', '.join(opts.participant_label))
-    #     if opts.run_uuid is not None:
-    #         run_uuid = opts.run_uuid
-    #         retval['run_uuid'] = run_uuid
+    #     if opts.runtime_uuid is not None:
+    #         runtime_uuid = opts.runtime_uuid
+    #         retval['runtime_uuid'] = runtime_uuid
     #     retval['return_code'] = generate_reports(
-    #         opts.participant_label, output_dir, work_dir, run_uuid,
+    #         opts.participant_label, output_dir, work_dir, runtime_uuid,
     #         packagename='funcworks')
     #     return retval
 
@@ -320,7 +321,7 @@ def build_workflow(opts, retval):
         Running FUNCWORKS version {__version__}:
           * BIDS dataset path: {bids_dir}.
           * Participant list: {retval['participant_label']}.
-          * Run identifier: {run_uuid}.
+          * Run identifier: {runtime_uuid}.
         """))
 
     if not opts.model_file:
@@ -339,7 +340,7 @@ def build_workflow(opts, retval):
         participants=retval['participant_label'],
         analysis_level=opts.analysis_level,
         smoothing=opts.smoothing,
-        run_uuid=run_uuid,
+        runtime_uuid=runtime_uuid,
         use_rapidart=opts.use_rapidart,
         detrend_poly=opts.detrend_poly,
         align_volumes=opts.align_volumes,

--- a/funcworks/cli/run.py
+++ b/funcworks/cli/run.py
@@ -84,7 +84,7 @@ def get_parser():
         help='Legendre polynomials to use for temporal filtering.')
     parser.add_argument(
         '--align-volumes', action='store',
-        default=None, type=int,
+        default=1, type=int,
         help='Bold reference to align timeseries, '
              'this will override any run specific inputs '
              'in the model file for the boldref and brain_mask.')

--- a/funcworks/interfaces/bids.py
+++ b/funcworks/interfaces/bids.py
@@ -167,7 +167,7 @@ class _BIDSDataGrabberInputSpec(DynamicTraitedSpec):
 
 
 class _BIDSDataGrabberOutputSpec(DynamicTraitedSpec):
-    bold_files = OutputMultiPath()
+    bold_files = OutputMultiPath(File)
 
 
 class BIDSDataGrabber(LibraryBaseInterface, IOBase):

--- a/funcworks/interfaces/bids.py
+++ b/funcworks/interfaces/bids.py
@@ -166,6 +166,10 @@ class _BIDSDataGrabberInputSpec(DynamicTraitedSpec):
         desc="Generate exception if list is empty for a given field")
 
 
+class _BIDSDataGrabberOutputSpec(DynamicTraitedSpec):
+    functional_files = OutputMultiPath()
+
+
 class BIDSDataGrabber(LibraryBaseInterface, IOBase):
     """
     Module that allows arbitrary query of BIDS Datasets.
@@ -191,7 +195,7 @@ class BIDSDataGrabber(LibraryBaseInterface, IOBase):
     """
 
     input_spec = _BIDSDataGrabberInputSpec
-    output_spec = DynamicTraitedSpec
+    output_spec = _BIDSDataGrabberOutputSpec
     _always_run = False
     _pkg = "bids"
 
@@ -258,10 +262,8 @@ class BIDSDataGrabber(LibraryBaseInterface, IOBase):
                 filelist = Undefined
 
             outputs[key] = filelist
-        return outputs
 
-    def _add_output_traits(self, base):
-        return add_traits(base, list(self.inputs.output_query.keys()))
+        return outputs['bold_files']
 
 
 def add_traits(base, names, trait_type=None):

--- a/funcworks/interfaces/bids.py
+++ b/funcworks/interfaces/bids.py
@@ -167,7 +167,7 @@ class _BIDSDataGrabberInputSpec(DynamicTraitedSpec):
 
 
 class _BIDSDataGrabberOutputSpec(DynamicTraitedSpec):
-    functional_files = OutputMultiPath()
+    bold_files = OutputMultiPath()
 
 
 class BIDSDataGrabber(LibraryBaseInterface, IOBase):

--- a/funcworks/interfaces/modelgen.py
+++ b/funcworks/interfaces/modelgen.py
@@ -12,7 +12,7 @@ from ..utils import snake_to_camel
 
 class _GetRunModelInfoInputSpec(BaseInterfaceInputSpec):
     bids_dir = Directory(exists=True, mandatory=True)
-    functional_file = InputMultiPath()
+    functional_file = traits.Either(File, traits.Str)
     database_path = Directory(exists=True, mandatory=True)
     model = traits.Dict(mandatory=True)
     detrend_poly = traits.Any(

--- a/funcworks/interfaces/modelgen.py
+++ b/funcworks/interfaces/modelgen.py
@@ -109,16 +109,32 @@ class GetRunModelInfo(IOBase):
         events_file = layout.get(
             **{**entities, 'desc': None, 'space': None,
                'suffix': 'events', 'extension': 'tsv'})[0].path
-        align_vols = {}
-        if self.inputs.align_volumes:
-            align_vols = {'run': self.inputs.align_volumes}
-        reference_image = layout.get(
-            **{**entities, **align_vols,
-               'suffix': 'boldref',
-               'desc': None})[0].path
-        mask_image = layout.get(
-            **{**entities, **align_vols,
-               'desc': 'brain', 'suffix': 'mask'})[0].path
+
+        if 'run' not in entities and self.inputs.align_volumes:
+            raise ValueError(
+                'align volumes is set, but dataset '
+                'does not appear to have multiple runs')
+        elif self.inputs.align_volumes:
+            reference_entities = {
+                **entities,
+                'run': self.inputs.align_volumes,
+                'suffix': 'boldref',
+                'desc': None}
+            mask_entities = {
+                **entities,
+                'run': self.inputs.align_volumes,
+                'desc': 'brain', 'suffix': 'mask'}
+        else:
+            reference_entities = {
+                **entities,
+                'suffix': 'boldref',
+                'desc': None}
+            mask_entities = {
+                **entities,
+                'desc': 'brain', 'suffix': 'mask'}
+
+        reference_image = layout.get(**reference_entities)[0].path
+        mask_image = layout.get(**mask_entities)[0].path
         return (regressor_file, meta_file, events_file,
                 reference_image, mask_image, entities)
 
@@ -342,13 +358,19 @@ class GenerateHigherInfo(IOBase):
             if 'effect' in org:
                 dof_data = np.ones_like(merged_image.get_fdata())
                 dofs = metadata.pop('DegreesOfFreedom')
-                if self.inputs.align_volumes:
+
+                if self.inputs.align_volumes and 'run' not in metadata:
+                    raise ValueError(
+                        'align_volumes is specified, but dataset '
+                        'does not appear to contain multiple runs')
+                elif self.inputs.align_volumes:
                     align_volume = self.inputs.align_volumes
+                    mask_entities = {**metadata, 'desc': 'brain',
+                                     'suffix': 'mask', 'run': align_volume}
                 else:
-                    align_volume = 1
-                mask_path = layout.get(
-                    **{**metadata, 'desc': 'brain',
-                       'suffix': 'mask', 'run': align_volume})
+                    mask_entities = {**metadata, 'desc': 'brain',
+                                     'suffix': 'mask'}
+                mask_path = layout.get(**mask_entities)
                 if len(mask_path) > 1:
                     raise ValueError('Entities given produced '
                                      'more than one mask file')

--- a/funcworks/interfaces/modelgen.py
+++ b/funcworks/interfaces/modelgen.py
@@ -43,7 +43,9 @@ class _GetRunModelInfoOutputSpec(TraitedSpec):
     reference_image = File(
         exists=True,
         desc='Reference Image for functional realignment')
-    brain_mask = File(exists=True, desc='Brain mask for functional image')
+    brain_mask = traits.Either(
+        File, traits.Str,
+        desc='Brain mask for functional image')
 
 
 class GetRunModelInfo(IOBase):

--- a/funcworks/interfaces/modelgen.py
+++ b/funcworks/interfaces/modelgen.py
@@ -110,7 +110,7 @@ class GetRunModelInfo(IOBase):
             **{**entities, 'desc': None, 'space': None,
                'suffix': 'events', 'extension': 'tsv'})[0].path
 
-        if 'run' not in entities and self.inputs.align_volumes:
+        if self.inputs.align_volumes and 'run' not in entities:
             raise ValueError(
                 'align volumes is set, but dataset '
                 'does not appear to have multiple runs')

--- a/funcworks/interfaces/modelgen.py
+++ b/funcworks/interfaces/modelgen.py
@@ -12,7 +12,7 @@ from ..utils import snake_to_camel
 
 class _GetRunModelInfoInputSpec(BaseInterfaceInputSpec):
     bids_dir = Directory(exists=True, mandatory=True)
-    functional_file = File(exists=True, mandatory=True)
+    functional_file = InputMultiPath()
     database_path = Directory(exists=True, mandatory=True)
     model = traits.Dict(mandatory=True)
     detrend_poly = traits.Any(

--- a/funcworks/interfaces/modelgen.py
+++ b/funcworks/interfaces/modelgen.py
@@ -259,7 +259,8 @@ class _GenerateHigherInfoInputSpec(BaseInterfaceInputSpec):
         desc='Contrast entities inherited from previous levels')
     model = traits.Dict(desc='Step level information from the model file')
     database_path = Directory(mandatory=True, exists=True)
-    align_volumes = traits.Int(
+    align_volumes = traits.Any(
+        default=None,
         desc=('Target volume for functional realignment',
               'if not value is specified, will not functional file'))
 

--- a/funcworks/interfaces/modelgen.py
+++ b/funcworks/interfaces/modelgen.py
@@ -40,8 +40,8 @@ class _GetRunModelInfoOutputSpec(TraitedSpec):
     repetition_time = traits.Float(desc='Repetition Time for the dataset')
     contrast_names = traits.List(
         desc='List of Contrast Names to pass to higher levels')
-    reference_image = File(
-        exists=True,
+    reference_image = traits.Either(
+        File, traits.Str,
         desc='Reference Image for functional realignment')
     brain_mask = traits.Either(
         File, traits.Str,

--- a/funcworks/workflows/base.py
+++ b/funcworks/workflows/base.py
@@ -14,7 +14,7 @@ def init_funcworks_wf(model_file,
                       participants,
                       analysis_level,
                       smoothing,
-                      run_uuid,
+                      runtime_uuid,
                       use_rapidart,
                       detrend_poly,
                       align_volumes,
@@ -63,7 +63,7 @@ def init_funcworks_wf(model_file,
             name=f'single_subject_{subject_id}_wf')
         crash_dir = (Path(output_dir) / 'funcworks'
                      / 'logs' / model['Name']
-                     / f'sub-{subject_id}' / run_uuid)
+                     / f'sub-{subject_id}' / runtime_uuid)
         crash_dir.mkdir(exist_ok=True, parents=True)
 
         single_subject_wf.config['execution']['crashdump_dir'] = str(crash_dir)

--- a/funcworks/workflows/fsl.py
+++ b/funcworks/workflows/fsl.py
@@ -73,6 +73,7 @@ def fsl_run_level_wf(model,
 
     wrangle_volumes = pe.MapNode(
         IdentityInterface(fields=['functional_file']),
+        iterfield=['functional_file'],
         name='wrangle_volumes'
     )
 

--- a/funcworks/workflows/fsl.py
+++ b/funcworks/workflows/fsl.py
@@ -309,9 +309,10 @@ def fsl_run_level_wf(model,
     else:
         workflow.connect([
             (get_info, mask_functional, [('brain_mask', 'in_file2')]),
-            (wrangle_volumes, mask_functional, [('out_file', 'in_file')]),
-            (mask_functional, specify_model,
-                [('out_file', 'functional_runs')]),
+            (wrangle_volumes, mask_functional, [
+                ('functional_file', 'in_file')]),
+            (mask_functional, specify_model, [
+                ('out_file', 'functional_runs')]),
             (mask_functional, fit_model, [('out_file', 'functional_data')]),
         ])
 
@@ -319,9 +320,9 @@ def fsl_run_level_wf(model,
         (get_info, specify_model, [('repetition_time', 'time_repetition')]),
 
         (specify_model, fit_model, [('session_info', 'session_info')]),
-        (get_info, fit_model, [('repetition_time', 'interscan_interval'),
-                               ('run_contrasts', 'contrasts')]),
-
+        (get_info, fit_model, [
+            ('repetition_time', 'interscan_interval'),
+            ('run_contrasts', 'contrasts')]),
         (fit_model, first_level_design, [
             ('interscan_interval', 'interscan_interval'),
             ('session_info', 'session_info'),
@@ -351,21 +352,25 @@ def fsl_run_level_wf(model,
         (generate_model, estimate_model, [('con_file', 'tcon_file')]),
         (estimate_model, calculate_p, [
             (('zstats', utils.flatten), 'in_file')]),
-        (estimate_model, collate, [('copes', 'effect_maps'),
-                                   ('varcopes', 'variance_maps'),
-                                   ('zstats', 'zscore_maps'),
-                                   ('tstats', 'tstat_maps')]),
+        (estimate_model, collate, [
+            ('copes', 'effect_maps'),
+            ('varcopes', 'variance_maps'),
+            ('zstats', 'zscore_maps'),
+            ('tstats', 'tstat_maps')]),
         (calculate_p, collate, [('out_file', 'pvalue_maps')]),
-        (collate, collate_outputs, [('effect_maps', 'effect_maps'),
-                                    ('variance_maps', 'variance_maps'),
-                                    ('zscore_maps', 'zscore_maps'),
-                                    ('pvalue_maps', 'pvalue_maps'),
-                                    ('tstat_maps', 'tstat_maps'),
-                                    ('contrast_metadata', 'metadata')]),
-        (collate_outputs, ds_contrast_maps, [('out', 'in_file'),
-                                             ('metadata', 'entities')]),
-        (collate_outputs, wrangle_outputs, [('metadata', 'contrast_metadata'),
-                                            ('out', 'contrast_maps')]),
+        (collate, collate_outputs, [
+            ('effect_maps', 'effect_maps'),
+            ('variance_maps', 'variance_maps'),
+            ('zscore_maps', 'zscore_maps'),
+            ('pvalue_maps', 'pvalue_maps'),
+            ('tstat_maps', 'tstat_maps'),
+            ('contrast_metadata', 'metadata')]),
+        (collate_outputs, ds_contrast_maps, [
+            ('out', 'in_file'),
+            ('metadata', 'entities')]),
+        (collate_outputs, wrangle_outputs, [
+            ('metadata', 'contrast_metadata'),
+            ('out', 'contrast_maps')]),
     ])
 
     return workflow

--- a/funcworks/workflows/fsl.py
+++ b/funcworks/workflows/fsl.py
@@ -71,8 +71,9 @@ def fsl_run_level_wf(model,
         iterfield=['in_file', 'ref_file'],
         name='func_realign')
 
-    wrangle_volumes = pe.Node(
+    wrangle_volumes = pe.MapNode(
         IdentityInterface(fields=['functional_file']),
+        iterfield=['functional_file'],
         name='wrangle_volumes'
     )
 

--- a/funcworks/workflows/fsl.py
+++ b/funcworks/workflows/fsl.py
@@ -71,9 +71,8 @@ def fsl_run_level_wf(model,
         iterfield=['in_file', 'ref_file'],
         name='func_realign')
 
-    wrangle_volumes = pe.MapNode(
+    wrangle_volumes = pe.Node(
         IdentityInterface(fields=['functional_file']),
-        iterfield=['functional_file'],
         name='wrangle_volumes'
     )
 


### PR DESCRIPTION
* Reworked run level workflow to allow passing of `realign_run` if `--align-volumes` isn't set
* Reworked `mask` and `reference` image grabbing in `GenRunModelInfo` and `GenHigherInfo` to not rely on `run` entity and to raise `ValueError` if align_volumes is assigned in a dataset with `run` entity